### PR TITLE
Respect display component weights.

### DIFF
--- a/eva.module
+++ b/eva.module
@@ -91,9 +91,9 @@ function eva_get_views($type = NULL, $reset = FALSE) {
 }
 
 /**
- * implement hook_entity_view_alter()
+ * Implements hook_entity_view()
  */
-function eva_entity_view_alter(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display) {
+function eva_entity_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
   $type = $entity->getEntityTypeId();
   $views = eva_get_views($type);
 


### PR DESCRIPTION
In D8, weights from display mode visibility settings are set in between hook_entity_view and hook_entity_view_alter. So because EVA didn't add its attached views until hook_entity_view_alter, views would show with the wrong weight. Simply changing to use hook_entity_view() fixes this.
